### PR TITLE
Performance improvement- GridPos should implement IEquatable<GridPos>

### DIFF
--- a/EpPathFinding/PathFinder/GridPos.cs
+++ b/EpPathFinding/PathFinder/GridPos.cs
@@ -42,7 +42,7 @@ using System.Text;
 
 namespace EpPathFinding.cs
 {
-    public struct GridPos
+    public struct GridPos : IEquatable<GridPos>
     {
         public int x;
         public int y;


### PR DESCRIPTION
Since GridPos did not implement IEquatable<GridPos>, the default
comparer for GridPos used its Object.Equals override which casts for
GridPos, instead of using the explicit implementation which avoid the
casting. This improves performance for everywhere that will compare
against GridPos.
The example I saw was in DynamicGrid.SetWalkableAt (line 149:
m_nodes.ContainsKey), saw a ~25% performance increase when building the
dynamic grid.