### PR TITLE
Performance- Add aggressive inlining hint

### DIFF
--- a/EpPathFinding.cs/EpPathFinding.cs/PathFinder/Grid/StaticGrid.cs
+++ b/EpPathFinding.cs/EpPathFinding.cs/PathFinder/Grid/StaticGrid.cs
@@ -38,6 +38,7 @@ An Interface for the StaticGrid Class.
 using System;
 using System.Collections.Generic;
 using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace EpPathFinding.cs
 {
@@ -124,11 +125,13 @@ namespace EpPathFinding.cs
             return this.m_nodes[iX][iY];
         }
 
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool IsWalkableAt(int iX, int iY)
         {
             return isInside(iX, iY) && this.m_nodes[iX][iY].walkable;
         }
 
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected bool isInside(int iX, int iY)
         {
             return (iX >= 0 && iX < width) && (iY >= 0 && iY < height);


### PR DESCRIPTION
This adds an aggressive inlining hint to the compiler for a minor increase in performance.
The IsWalkableAt proved to be the biggest bottleneck for my use-case after profiling the code (which is why I added the hint there).

Benchmarked before & after with Benchmark.Net (the use-case I was benchmarking, an all-true mask of 1000X1000, going from 0,0 to 1000,1000):

Before-
```
 Method |  Job | Runtime |     Mean |    Error |   StdDev | Scaled | ScaledSD | Rank |      Gen 0 | Allocated |
------- |----- |-------- |---------:|---------:|---------:|-------:|---------:|-----:|-----------:|----------:|
   Test |  Clr |     Clr | 214.6 ms | 3.151 ms | 2.793 ms |   1.00 |     0.00 |    2 | 15333.3333 |       0 B |
   Test | Mono |    Mono | 209.0 ms | 2.738 ms | 2.427 ms |   0.97 |     0.02 |    1 | 17333.3333 |       N/A |
```
After-
```
Method |  Job | Runtime |     Mean |    Error |    StdDev |   Median | Scaled | ScaledSD | Rank |      Gen 0 | Allocated |
------- |----- |-------- |---------:|---------:|----------:|---------:|-------:|---------:|-----:|-----------:|----------:|
   Test |  Clr |     Clr | 209.1 ms | 4.777 ms | 10.076 ms | 204.8 ms |   1.00 |     0.00 |    2 | 15333.3333 |       0 B |
   Test | Mono |    Mono | 197.9 ms | 2.982 ms |  2.789 ms | 198.3 ms |   0.95 |     0.04 |    1 | 17333.3333 |       N/A |
```